### PR TITLE
fix configure options

### DIFF
--- a/configure
+++ b/configure
@@ -1,12 +1,6 @@
 --with-mailpath=/var/spool/mail/
---enable-imap
---enable-pop
---enable-smtp
---with-gnutls=yes
---with-gss=yes
---with-notmuch=yes
---with-sasl=yes
---enable-sidebar
---enable-hcache
---enable-debug
---with-lmdb=yes
+--gnutls
+--gss
+--notmuch
+--sasl
+--lmdb


### PR DESCRIPTION
I don't use Clear Linux, myself, so take the PR with a pinch of salt :-)

---

Use up-to-date configure options:

* -`-gnutls`
* `--gss`
* `--lmdb`
* `--notmuch`
* `--sasl`

Drop options that are built-in by default:

* `--enable-hcache`
* `--enable-imap`
* `--enable-pop`
* `--enable-sidebar`
* `--enable-smtp`

Drop option that's used by autosetup, not NeoMutt

* `--enable-debug`